### PR TITLE
2x performance improvement from using lfsr64 instead of xoshiro

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/c2h5oh/datasize"
-	"github.com/kbjorklu/xoshiro"
+	"github.com/jes/lfsr64"
 	flag "github.com/spf13/pflag"
 )
 
@@ -58,7 +58,7 @@ func writeData() {
 
 // r is the source of randomness used for data generation.
 // TODO Allow this to be seeded.
-var r = xoshiro.NewXoshiro256StarStar(99)
+var r = lfsr64.NewLfsr64(99)
 
 // genDataChunk generates the next chunk of random data in c.
 func genDataChunk(c []byte) {


### PR DESCRIPTION
LFSR64 is a simpler RNG than xoshiro, and provides adequate randomness in cases where speed is most important.

This version:
```
$ ./rdspam -s 10000000 | ent
Entropy = 7.999889 bits per byte.

Optimum compression would reduce the size
of this 10000000 byte file by 0 percent.

Chi square distribution for 10000000 samples is 1540.41, and randomly
would exceed this value less than 0.01 percent of the times.

Arithmetic mean value of data bytes is 127.5194 (127.5 = random).
Monte Carlo value for Pi is 3.141858057 (error 0.01 percent).
Serial correlation coefficient is 0.001311 (totally uncorrelated = 0.0).
```
Previous version:
```
$ ./rdspam.orig -s 10000000 | ent
Entropy = 7.999980 bits per byte.

Optimum compression would reduce the size
of this 10000000 byte file by 0 percent.

Chi square distribution for 10000000 samples is 279.14, and randomly
would exceed this value 14.31 percent of the times.

Arithmetic mean value of data bytes is 127.5131 (127.5 = random).
Monte Carlo value for Pi is 3.141224456 (error 0.01 percent).
Serial correlation coefficient is 0.000151 (totally uncorrelated = 0.0).
```
The only material difference is the chi-square distribution, which looks random from xoshiro and not random from lfsr64.

I don't mind if you don't merge this, just having fun really :p